### PR TITLE
Update pydantic to 2.10.5 for Python 3.13 compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ botocore==1.34.0
 
 # Configuration
 pyyaml==6.0.1
-pydantic==2.5.0
+pydantic==2.10.5
 
 # Utilities
 python-dotenv==1.0.0


### PR DESCRIPTION
## Summary
- Updated pydantic from 2.5.0 to 2.10.5 to support Python 3.13

## Problem
The previous version (pydantic 2.5.0) failed to install on Python 3.13 due to compatibility issues in pydantic-core with `ForwardRef._evaluate()` which changed in Python 3.13.

## Solution
Updated to pydantic 2.10.5 which includes:
- Full Python 3.13 support
- Pre-built wheels for macOS ARM64
- All dependencies now install successfully

## Test plan
- [x] Verified `pip install -r requirements.txt` completes successfully
- [ ] Run existing tests to ensure no breaking changes
- [ ] Verify application functionality with new pydantic version

🤖 Generated with [Claude Code](https://claude.com/claude-code)