### PR TITLE
Fix OpenRouter message formatting for image-only messages

### DIFF
--- a/src/handlers/message_handler.py
+++ b/src/handlers/message_handler.py
@@ -170,9 +170,16 @@ class MessageHandler:
                         }
                     )
 
-        # Add text
+        # Add text - Anthropic's API requires text content
+        # If there's no text but we have images, add a placeholder
         if text:
             content.append({"type": "text", "text": text})
+        elif images:
+            # Images present but no text - add placeholder for LLM to analyze
+            content.append({"type": "text", "text": "Please analyze this image."})
+        else:
+            # No images and no text - add minimal content to avoid API error
+            content.append({"type": "text", "text": "Hello"})
 
         return {"role": "user", "content": content}
 


### PR DESCRIPTION
## Summary
- Fixes API error when posting images without text to channels that require images (e.g., calorie channel)
- Ensures compatibility with Anthropic's Messages API requirements via OpenRouter

## Problem
When users post images without any caption text, OpenRouter was returning HTTP 400 errors:
```
messages.0: all messages must have non-empty content except for the optional final assistant message
```

This issue only appeared after migrating to OpenRouter because:
- AWS Bedrock allowed messages with only image content blocks
- Anthropic's Messages API (used by OpenRouter) requires all user messages to have text content, even when images are present

## Solution
Updated `_format_message()` in `message_handler.py` to always include text content:
- If user provides text: uses their text (normal case)
- If no text but has images: adds placeholder "Please analyze this image."
- If neither: adds minimal "Hello" (edge case)

## Testing
- Tested with calorie channel that has `require_image: true`
- Works correctly with images posted with or without text captions
- Placeholder text works well with system prompts expecting image analysis

🤖 Generated with [Claude Code](https://claude.com/claude-code)