### PR TITLE
Add OpenRouter app attribution headers

### DIFF
--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -28,6 +28,11 @@ channels:
       temperature: 0.7
       # base_url: "https://openrouter.ai/api/v1"  # Optional, this is the default
 
+      # App attribution headers (optional - shown in OpenRouter console)
+      # These defaults are used if not specified:
+      # site_url: "https://github.com/tgrecojr/slacklistener"  # Your app URL for rankings
+      # site_name: "slacklistener"  # Your app name shown in OpenRouter console
+
     system_prompt: |
       You are a helpful support assistant. When users report issues,
       provide clear, actionable guidance. Be friendly and professional.

--- a/src/handlers/command_handler.py
+++ b/src/handlers/command_handler.py
@@ -156,6 +156,8 @@ class CommandHandler:
                 api_key=command_config.llm.api_key,
                 model=command_config.llm.model,
                 base_url=command_config.llm.base_url,
+                site_url=command_config.llm.site_url,
+                site_name=command_config.llm.site_name,
             )
 
             # Create simple text message

--- a/src/handlers/message_handler.py
+++ b/src/handlers/message_handler.py
@@ -87,7 +87,9 @@ class MessageHandler:
 
             # Check if we should respond to this message
             if channel_config.require_image and not has_images:
-                logger.debug("Message has no images with valid data, skipping (require_image=True)")
+                logger.debug(
+                    "Message has no images with valid data, skipping (require_image=True)"
+                )
                 return
 
             # Check keywords
@@ -208,6 +210,8 @@ class MessageHandler:
                 api_key=channel_config.llm.api_key,
                 model=channel_config.llm.model,
                 base_url=channel_config.llm.base_url,
+                site_url=channel_config.llm.site_url,
+                site_name=channel_config.llm.site_name,
             )
 
             # Format message

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -50,13 +50,22 @@ class LLMConfig(BaseModel):
     api_key: str = Field(..., description="OpenRouter API key")
     model: str = Field(
         default="anthropic/claude-3.5-sonnet",
-        description="Model identifier (e.g., anthropic/claude-3.5-sonnet, openai/gpt-4)"
+        description="Model identifier (e.g., anthropic/claude-3.5-sonnet, openai/gpt-4)",
     )
     max_tokens: int = Field(default=1024, ge=1, le=100000)
     temperature: float = Field(default=0.7, ge=0.0, le=1.0)
     base_url: str = Field(
-        default="https://openrouter.ai/api/v1",
-        description="OpenRouter API base URL"
+        default="https://openrouter.ai/api/v1", description="OpenRouter API base URL"
+    )
+
+    # App attribution headers
+    site_url: str = Field(
+        default="https://github.com/tgrecojr/slacklistener",
+        description="App URL for OpenRouter attribution (shown in rankings)",
+    )
+    site_name: str = Field(
+        default="slacklistener",
+        description="App name for OpenRouter attribution (shown in console)",
     )
 
 


### PR DESCRIPTION
## Summary
- Adds HTTP-Referer and X-Title headers to all OpenRouter API calls
- Enables proper app identification in OpenRouter console and rankings
- App now shows as "slacklistener" instead of "Unknown" in OpenRouter UI

## Changes
- Added `site_url` and `site_name` fields to `LLMConfig` with sensible defaults
- Updated `OpenRouterClient.__init__()` to accept attribution parameters
- Modified `generate_response()` to include `extra_headers` in API calls
- Updated client instantiation in `message_handler.py` and `command_handler.py`
- Documented the attribution headers in `config.example.yaml`
- Applied black formatting to modified files

## Configuration
The defaults are set to:
- `site_url`: `https://github.com/tgrecojr/slacklistener`
- `site_name`: `slacklistener`

Users can optionally override these in their config.yaml if desired.

## Testing
- ✅ Python syntax validation passed
- ✅ Black formatting applied
- ✅ Pylint checks passed (8.42/10 - pre-existing issues only)
- ⚠️  Tests not run - pre-existing test failures on main due to incomplete Bedrock→OpenRouter migration

## References
- [OpenRouter App Attribution Documentation](https://openrouter.ai/docs/app-attribution)

🤖 Generated with [Claude Code](https://claude.com/claude-code)