### PR TITLE
feat: add /F1 slash command and F1 tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,23 @@ tools:
 - Content monitoring
 - Feed aggregation
 
+#### F1 Tool
+
+Fetches current-season Formula 1 data from the public [f1api.dev](https://f1api.dev) API: driver and constructor standings, the last race's podium, and the next race's schedule. When today falls within the Friday–Sunday window of the next race, it also pulls qualifying results, and pulls sprint results on sprint weekends.
+
+**Configuration:**
+```yaml
+tools:
+  - type: "f1"
+    # Both fields optional; defaults shown
+    # base_url: "https://f1api.dev/api"
+    # request_timeout: 10
+```
+
+**Use Cases:**
+- F1 race-weekend briefings (`/F1` command)
+- Standings updates between race weekends
+
 **Example Integration:**
 ```yaml
 slash_commands:
@@ -260,7 +277,7 @@ The application uses [OpenRouter](https://openrouter.ai) as a unified gateway to
 
 5. **Create Slash Commands** (optional):
    - Go to "Slash Commands"
-   - Create commands matching your `config.yaml` (e.g., `/analyze`, `/summarize`, `/news`)
+   - Create commands matching your `config.yaml` (e.g., `/analyze`, `/summarize`, `/news`, `/F1`)
 
 6. **Install App to Workspace**:
    - Go to "Install App"
@@ -381,7 +398,8 @@ slacklistener/
 │   │   ├── factory.py           # Tool factory
 │   │   └── implementations/
 │   │       ├── openweathermap.py    # OpenWeatherMap tool
-│   │       └── rssfeed.py           # RSS Feed tool
+│   │       ├── rssfeed.py           # RSS Feed tool
+│   │       └── f1.py                # F1 (f1api.dev) tool
 │   ├── utils/
 │   │   ├── config.py            # Configuration loading
 │   │   └── slack_helpers.py     # Slack utilities

--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -268,6 +268,33 @@ slash_commands:
         data_file: "data/news_seen_articles.json"
         max_stories: 10
 
+  # Example: /F1 command for Formula 1 standings and race info
+  - command: "/F1"
+    description: "Current F1 standings, last race podium, and next race details"
+    enabled: true
+
+    llm:
+      api_key: "${OPENROUTER_API_KEY}"
+      model: "anthropic/claude-3.5-sonnet"
+      max_tokens: 1500
+      temperature: 0.5
+
+    system_prompt: |
+      You are a Formula 1 reporter. Using the F1 data provided, produce a concise
+      briefing that includes:
+      - Top of the current drivers' championship (top 5)
+      - Top of the constructors' championship (top 5)
+      - The podium from the last race
+      - The next race: name, circuit, date, and key session times
+      If qualifying or sprint results are present, summarize the top performers and
+      note that the weekend is in progress. Use bullet points and keep it under 250 words.
+
+    tools:
+      - type: "f1"
+        # Both fields are optional; defaults shown below
+        # base_url: "https://f1api.dev/api"
+        # request_timeout: 10
+
 # Global settings
 settings:
   # Log level: DEBUG, INFO, WARNING, ERROR

--- a/src/tools/factory.py
+++ b/src/tools/factory.py
@@ -72,5 +72,13 @@ def create_tool(tool_config: Dict[str, Any]) -> Tool:
             max_stories=tool_config.get("max_stories", 10),
         )
 
+    elif tool_type == "f1":
+        from .implementations.f1 import F1Tool
+
+        return F1Tool(
+            base_url=tool_config.get("base_url", F1Tool.DEFAULT_BASE_URL),
+            request_timeout=tool_config.get("request_timeout", 10),
+        )
+
     else:
         raise ValueError(f"Unknown tool type: {tool_type}")

--- a/src/tools/implementations/f1.py
+++ b/src/tools/implementations/f1.py
@@ -1,0 +1,287 @@
+"""F1 API tool for Formula 1 standings and race data enrichment."""
+
+import logging
+from datetime import date, datetime, timedelta
+from typing import Any, Dict, List, Optional
+
+import requests
+
+from ..tool import Tool
+
+logger = logging.getLogger(__name__)
+
+
+class F1Tool(Tool):
+    """Tool to fetch F1 standings, last race, next race, and weekend session data."""
+
+    DEFAULT_BASE_URL = "https://f1api.dev/api"
+
+    def __init__(
+        self,
+        base_url: str = DEFAULT_BASE_URL,
+        request_timeout: int = 10,
+        today: Optional[date] = None,
+    ):
+        """
+        Initialize the F1 tool.
+
+        Args:
+            base_url: Base URL for the f1api.dev API
+            request_timeout: HTTP request timeout in seconds
+            today: Override "today" for race-weekend detection (used in tests)
+        """
+        self.base_url = base_url.rstrip("/")
+        self.request_timeout = request_timeout
+        self._today_override = today
+
+    def get_name(self) -> str:
+        return "F1"
+
+    def execute(self, context: Dict[str, Any]) -> str:
+        today = self._today_override or date.today()
+
+        driver_standings = self._safe_fetch(
+            f"{self.base_url}/current/drivers-championship"
+        )
+        constructor_standings = self._safe_fetch(
+            f"{self.base_url}/current/constructors-championship"
+        )
+        last_race = self._safe_fetch(f"{self.base_url}/current/last/race")
+        next_race = self._safe_fetch(f"{self.base_url}/current/next")
+
+        sections: List[str] = []
+        sections.append(self._format_driver_standings(driver_standings))
+        sections.append(self._format_constructor_standings(constructor_standings))
+        sections.append(self._format_last_race_podium(last_race))
+        sections.append(self._format_next_race(next_race))
+
+        if self._is_race_weekend(next_race, today):
+            qualy = self._safe_fetch(f"{self.base_url}/current/last/qualy")
+            sections.append(self._format_qualifying(qualy))
+
+            if self._is_sprint_weekend(next_race):
+                sprint = self._safe_fetch(f"{self.base_url}/current/last/sprint")
+                sprint_section = self._format_sprint(sprint)
+                if sprint_section:
+                    sections.append(sprint_section)
+
+        return "\n\n".join(s for s in sections if s)
+
+    # --- HTTP --------------------------------------------------------------
+
+    def _safe_fetch(self, url: str) -> Optional[Dict[str, Any]]:
+        try:
+            response = requests.get(url, timeout=self.request_timeout)
+            response.raise_for_status()
+            return response.json()
+        except Exception as e:  # noqa: BLE001 — surface upstream failures gracefully
+            logger.warning(f"F1 API request failed for {url}: {e}")
+            return None
+
+    # --- Race weekend detection -------------------------------------------
+
+    def _is_race_weekend(
+        self, next_race_payload: Optional[Dict[str, Any]], today: date
+    ) -> bool:
+        race_date = self._extract_next_race_date(next_race_payload)
+        if not race_date:
+            return False
+        # Race is Sunday; weekend window is Fri (-2) through Sun (race day).
+        weekend_start = race_date - timedelta(days=2)
+        return weekend_start <= today <= race_date
+
+    def _is_sprint_weekend(self, next_race_payload: Optional[Dict[str, Any]]) -> bool:
+        race = (next_race_payload or {}).get("race") or {}
+        schedule = race.get("schedule") or {}
+        sprint_race = schedule.get("sprintRace") or {}
+        return bool(sprint_race.get("date"))
+
+    def _extract_next_race_date(
+        self, next_race_payload: Optional[Dict[str, Any]]
+    ) -> Optional[date]:
+        race = (next_race_payload or {}).get("race") or {}
+        schedule = race.get("schedule") or {}
+        race_block = schedule.get("race") or {}
+        date_str = race_block.get("date")
+        if not date_str:
+            return None
+        try:
+            return datetime.strptime(date_str, "%Y-%m-%d").date()
+        except ValueError:
+            logger.warning(f"Unparseable next race date: {date_str}")
+            return None
+
+    # --- Formatters -------------------------------------------------------
+
+    def _format_driver_standings(self, payload: Optional[Dict[str, Any]]) -> str:
+        header = "DRIVER STANDINGS (current season):"
+        if not payload:
+            return f"{header}\n- unavailable"
+        rows = payload.get("drivers_championship") or []
+        if not rows:
+            return f"{header}\n- unavailable"
+
+        lines = [header]
+        for entry in rows[:10]:
+            position = entry.get("position", "?")
+            points = entry.get("points", 0)
+            wins = entry.get("wins", 0)
+            driver = entry.get("driver") or {}
+            team = entry.get("team") or {}
+            surname = driver.get("surname") or ""
+            given = driver.get("name") or ""
+            team_name = team.get("teamName") or ""
+            lines.append(
+                f"{position}. {surname} ({given}) — {team_name} — {points} pts, {wins} wins"
+            )
+        return "\n".join(lines)
+
+    def _format_constructor_standings(self, payload: Optional[Dict[str, Any]]) -> str:
+        header = "CONSTRUCTOR STANDINGS (current season):"
+        if not payload:
+            return f"{header}\n- unavailable"
+        rows = payload.get("constructors_championship") or []
+        if not rows:
+            return f"{header}\n- unavailable"
+
+        lines = [header]
+        for entry in rows:
+            position = entry.get("position", "?")
+            points = entry.get("points", 0)
+            wins = entry.get("wins", 0)
+            team = entry.get("team") or {}
+            team_name = team.get("teamName") or ""
+            lines.append(f"{position}. {team_name} — {points} pts, {wins} wins")
+        return "\n".join(lines)
+
+    def _format_last_race_podium(self, payload: Optional[Dict[str, Any]]) -> str:
+        header = "LAST RACE PODIUM:"
+        race = self._first_race(payload)
+        if not race:
+            return f"{header}\n- unavailable"
+
+        race_name = race.get("raceName") or "Unknown race"
+        race_date = race.get("date") or ""
+        circuit = (race.get("circuit") or {}).get("circuitName") or ""
+
+        lines = [header, f"{race_name} ({race_date}) — {circuit}".strip(" —")]
+
+        results = race.get("results") or []
+        for entry in results[:3]:
+            position = entry.get("position", "?")
+            time_str = entry.get("time") or ""
+            driver = entry.get("driver") or {}
+            team = entry.get("team") or {}
+            surname = driver.get("surname") or ""
+            team_name = team.get("teamName") or ""
+            lines.append(f"{position}. {surname} ({team_name}) {time_str}".rstrip())
+        return "\n".join(lines)
+
+    def _format_next_race(self, payload: Optional[Dict[str, Any]]) -> str:
+        header = "NEXT RACE:"
+        if not payload:
+            return f"{header}\n- unavailable"
+        race = payload.get("race") or {}
+        if not race:
+            return f"{header}\n- unavailable"
+
+        name = race.get("raceName") or "Unknown"
+        round_no = race.get("round") or payload.get("round")
+        schedule = race.get("schedule") or {}
+        race_block = schedule.get("race") or {}
+        race_date = race_block.get("date") or ""
+        race_time = race_block.get("time") or ""
+        circuit = race.get("circuit") or {}
+        circuit_name = circuit.get("circuitName") or ""
+        city = circuit.get("city") or ""
+        country = circuit.get("country") or ""
+        location = ", ".join(p for p in [city, country] if p)
+
+        lines = [
+            header,
+            f"Round {round_no}: {name}",
+            f"Date: {race_date} {race_time}".strip(),
+            f"Circuit: {circuit_name}" + (f" — {location}" if location else ""),
+        ]
+
+        qualy_block = schedule.get("qualy") or {}
+        if qualy_block.get("date"):
+            lines.append(
+                f"Qualifying: {qualy_block.get('date')} {qualy_block.get('time') or ''}".strip()
+            )
+        sprint_block = schedule.get("sprintRace") or {}
+        if sprint_block.get("date"):
+            lines.append(
+                f"Sprint: {sprint_block.get('date')} {sprint_block.get('time') or ''}".strip()
+            )
+        return "\n".join(lines)
+
+    def _format_qualifying(self, payload: Optional[Dict[str, Any]]) -> str:
+        header = "QUALIFYING (most recent session):"
+        race = self._race_block(payload)
+        if not race:
+            return f"{header}\n- unavailable"
+
+        race_name = race.get("raceName") or ""
+        results = race.get("qualyResults") or []
+        if not results:
+            return f"{header}\n- unavailable"
+
+        lines = [header, f"{race_name}".strip()]
+        for entry in results[:10]:
+            grid = entry.get("gridPosition", "?")
+            driver = entry.get("driver") or {}
+            team = entry.get("team") or {}
+            surname = driver.get("surname") or ""
+            team_name = team.get("teamName") or ""
+            q3 = entry.get("q3") or entry.get("q2") or entry.get("q1") or ""
+            lines.append(f"{grid}. {surname} ({team_name}) {q3}".rstrip())
+        return "\n".join(lines)
+
+    def _format_sprint(self, payload: Optional[Dict[str, Any]]) -> Optional[str]:
+        race = self._race_block(payload)
+        if not race:
+            return None
+        results = race.get("sprintResults") or []
+        if not results:
+            return None
+
+        header = "SPRINT RESULTS (most recent session):"
+        race_name = race.get("raceName") or ""
+        lines = [header, f"{race_name}".strip()]
+        for entry in results[:8]:
+            position = entry.get("position", "?")
+            driver = entry.get("driver") or {}
+            team = entry.get("team") or {}
+            surname = driver.get("surname") or ""
+            team_name = team.get("teamName") or ""
+            lines.append(f"{position}. {surname} ({team_name})")
+        return "\n".join(lines)
+
+    # --- Payload helpers --------------------------------------------------
+
+    def _first_race(
+        self, payload: Optional[Dict[str, Any]]
+    ) -> Optional[Dict[str, Any]]:
+        """Return the first race from a `races` list payload."""
+        if not payload:
+            return None
+        races = payload.get("races")
+        if isinstance(races, list) and races:
+            return races[0]
+        if isinstance(races, dict):
+            return races
+        return None
+
+    def _race_block(
+        self, payload: Optional[Dict[str, Any]]
+    ) -> Optional[Dict[str, Any]]:
+        """Return the race object for qualy/sprint payloads (races may be dict or list)."""
+        if not payload:
+            return None
+        races = payload.get("races")
+        if isinstance(races, dict):
+            return races
+        if isinstance(races, list) and races:
+            return races[0]
+        return None

--- a/tests/unit/test_f1_tool.py
+++ b/tests/unit/test_f1_tool.py
@@ -1,0 +1,484 @@
+"""Tests for the F1 tool."""
+
+from datetime import date
+
+import pytest
+import responses
+
+from src.tools.factory import create_tool
+from src.tools.implementations.f1 import F1Tool
+
+F1_BASE = "https://f1api.dev/api"
+
+
+# --- Sample API payloads -------------------------------------------------
+
+DRIVER_STANDINGS = {
+    "season": 2026,
+    "drivers_championship": [
+        {
+            "position": 1,
+            "points": 100,
+            "wins": 3,
+            "driver": {
+                "name": "Andrea Kimi",
+                "surname": "Antonelli",
+                "shortName": "ANT",
+            },
+            "team": {"teamName": "Mercedes"},
+        },
+        {
+            "position": 2,
+            "points": 88,
+            "wins": 2,
+            "driver": {"name": "Max", "surname": "Verstappen", "shortName": "VER"},
+            "team": {"teamName": "Red Bull"},
+        },
+        {
+            "position": 3,
+            "points": 72,
+            "wins": 1,
+            "driver": {"name": "Charles", "surname": "Leclerc", "shortName": "LEC"},
+            "team": {"teamName": "Ferrari"},
+        },
+    ],
+}
+
+CONSTRUCTOR_STANDINGS = {
+    "season": 2026,
+    "constructors_championship": [
+        {"position": 1, "points": 180, "wins": 4, "team": {"teamName": "Mercedes"}},
+        {"position": 2, "points": 150, "wins": 3, "team": {"teamName": "Red Bull"}},
+        {"position": 3, "points": 130, "wins": 1, "team": {"teamName": "Ferrari"}},
+    ],
+}
+
+LAST_RACE = {
+    "season": 2026,
+    "races": [
+        {
+            "round": 6,
+            "date": "2026-05-03",
+            "raceName": "Miami Grand Prix",
+            "circuit": {
+                "circuitName": "Miami International Autodrome",
+                "country": "USA",
+            },
+            "results": [
+                {
+                    "position": 1,
+                    "time": "1:32:45.123",
+                    "driver": {"name": "Andrea Kimi", "surname": "Antonelli"},
+                    "team": {"teamName": "Mercedes"},
+                },
+                {
+                    "position": 2,
+                    "time": "+3.456",
+                    "driver": {"name": "Max", "surname": "Verstappen"},
+                    "team": {"teamName": "Red Bull"},
+                },
+                {
+                    "position": 3,
+                    "time": "+8.901",
+                    "driver": {"name": "Charles", "surname": "Leclerc"},
+                    "team": {"teamName": "Ferrari"},
+                },
+                {
+                    "position": 4,
+                    "time": "+12.345",
+                    "driver": {"name": "Lando", "surname": "Norris"},
+                    "team": {"teamName": "McLaren"},
+                },
+            ],
+        }
+    ],
+}
+
+NEXT_RACE = {
+    "season": 2026,
+    "round": 7,
+    "race": {
+        "raceName": "Emilia-Romagna Grand Prix",
+        "round": 7,
+        "schedule": {
+            "race": {"date": "2026-05-17", "time": "13:00:00Z"},
+            "qualy": {"date": "2026-05-16", "time": "14:00:00Z"},
+            "fp1": {"date": "2026-05-15", "time": "11:30:00Z"},
+            "fp2": {"date": "2026-05-15", "time": "15:00:00Z"},
+            "fp3": {"date": "2026-05-16", "time": "10:30:00Z"},
+            "sprintQualy": {"date": None, "time": None},
+            "sprintRace": {"date": None, "time": None},
+        },
+        "circuit": {
+            "circuitName": "Autodromo Enzo e Dino Ferrari",
+            "country": "Italy",
+            "city": "Imola",
+        },
+    },
+}
+
+NEXT_RACE_SPRINT_WEEKEND = {
+    "season": 2026,
+    "round": 8,
+    "race": {
+        "raceName": "Belgian Grand Prix",
+        "round": 8,
+        "schedule": {
+            "race": {"date": "2026-05-24", "time": "13:00:00Z"},
+            "qualy": {"date": "2026-05-22", "time": "16:00:00Z"},
+            "fp1": {"date": "2026-05-22", "time": "11:30:00Z"},
+            "fp2": {"date": "2026-05-23", "time": "10:30:00Z"},
+            "fp3": {"date": None, "time": None},
+            "sprintQualy": {"date": "2026-05-23", "time": "14:30:00Z"},
+            "sprintRace": {"date": "2026-05-24", "time": "10:00:00Z"},
+        },
+        "circuit": {
+            "circuitName": "Circuit de Spa-Francorchamps",
+            "country": "Belgium",
+            "city": "Spa",
+        },
+    },
+}
+
+LAST_QUALY = {
+    "season": 2026,
+    "races": {
+        "round": 6,
+        "raceName": "Miami Grand Prix",
+        "qualyDate": "2026-05-02",
+        "circuit": {"circuitName": "Miami International Autodrome"},
+        "qualyResults": [
+            {
+                "gridPosition": 1,
+                "q1": "1:28.500",
+                "q2": "1:28.000",
+                "q3": "1:27.798",
+                "driver": {"name": "Andrea Kimi", "surname": "Antonelli"},
+                "team": {"teamName": "Mercedes"},
+            },
+            {
+                "gridPosition": 2,
+                "q1": "1:28.600",
+                "q2": "1:28.100",
+                "q3": "1:27.900",
+                "driver": {"name": "Max", "surname": "Verstappen"},
+                "team": {"teamName": "Red Bull"},
+            },
+            {
+                "gridPosition": 3,
+                "q1": "1:28.700",
+                "q2": "1:28.200",
+                "q3": "1:28.050",
+                "driver": {"name": "Charles", "surname": "Leclerc"},
+                "team": {"teamName": "Ferrari"},
+            },
+        ],
+    },
+}
+
+LAST_SPRINT = {
+    "season": 2026,
+    "races": {
+        "round": 8,
+        "raceName": "Belgian Grand Prix",
+        "circuit": {"circuitName": "Circuit de Spa-Francorchamps"},
+        "sprintResults": [
+            {
+                "position": 1,
+                "driver": {"name": "Max", "surname": "Verstappen"},
+                "team": {"teamName": "Red Bull"},
+            },
+            {
+                "position": 2,
+                "driver": {"name": "Andrea Kimi", "surname": "Antonelli"},
+                "team": {"teamName": "Mercedes"},
+            },
+            {
+                "position": 3,
+                "driver": {"name": "Lando", "surname": "Norris"},
+                "team": {"teamName": "McLaren"},
+            },
+        ],
+    },
+}
+
+
+def _register_core_endpoints():
+    """Register the four always-fetched endpoints."""
+    responses.add(
+        responses.GET,
+        f"{F1_BASE}/current/drivers-championship",
+        json=DRIVER_STANDINGS,
+        status=200,
+    )
+    responses.add(
+        responses.GET,
+        f"{F1_BASE}/current/constructors-championship",
+        json=CONSTRUCTOR_STANDINGS,
+        status=200,
+    )
+    responses.add(
+        responses.GET,
+        f"{F1_BASE}/current/last/race",
+        json=LAST_RACE,
+        status=200,
+    )
+
+
+class TestF1ToolBasics:
+    """Initialization and basic behavior."""
+
+    def test_get_name(self):
+        tool = F1Tool()
+        assert tool.get_name() == "F1"
+
+    def test_default_base_url(self):
+        tool = F1Tool()
+        assert tool.base_url == F1_BASE
+
+
+class TestF1ToolOutsideRaceWeekend:
+    """Behavior when today is NOT within Fri-Sun of the next race."""
+
+    @responses.activate
+    def test_execute_includes_standings_podium_and_next_race(self):
+        _register_core_endpoints()
+        responses.add(
+            responses.GET,
+            f"{F1_BASE}/current/next",
+            json=NEXT_RACE,
+            status=200,
+        )
+
+        # Tuesday before the May 17 race — not race weekend
+        tool = F1Tool(today=date(2026, 5, 12))
+        result = tool.execute({"user_input": "F1"})
+
+        # Driver standings
+        assert "DRIVER STANDINGS" in result
+        assert "1. Antonelli" in result
+        assert "Mercedes" in result
+        assert "100" in result  # points
+
+        # Constructor standings
+        assert "CONSTRUCTOR STANDINGS" in result
+        assert "180" in result
+
+        # Last race podium
+        assert "LAST RACE" in result
+        assert "Miami Grand Prix" in result
+        assert "Antonelli" in result
+        assert "Verstappen" in result
+        assert "Leclerc" in result
+        # Should not include 4th place
+        assert "Norris" not in result
+
+        # Next race
+        assert "NEXT RACE" in result
+        assert "Emilia-Romagna Grand Prix" in result
+        assert "Imola" in result
+        assert "2026-05-17" in result
+
+        # Outside race weekend — no qualy section
+        assert "QUALIFYING" not in result
+        assert "SPRINT" not in result
+
+    @responses.activate
+    def test_qualy_not_fetched_outside_race_weekend(self):
+        """During non-weekend days, the qualy endpoint should not be called."""
+        _register_core_endpoints()
+        responses.add(
+            responses.GET,
+            f"{F1_BASE}/current/next",
+            json=NEXT_RACE,
+            status=200,
+        )
+
+        tool = F1Tool(today=date(2026, 5, 12))
+        tool.execute({"user_input": "F1"})
+
+        called = [r.request.url for r in responses.calls]
+        assert not any("qualy" in u for u in called)
+        assert not any("sprint" in u for u in called)
+
+
+class TestF1ToolRaceWeekend:
+    """Behavior when today is within Fri-Sun of the next race."""
+
+    @responses.activate
+    def test_includes_qualifying_during_race_weekend(self):
+        _register_core_endpoints()
+        responses.add(
+            responses.GET,
+            f"{F1_BASE}/current/next",
+            json=NEXT_RACE,
+            status=200,
+        )
+        responses.add(
+            responses.GET,
+            f"{F1_BASE}/current/last/qualy",
+            json=LAST_QUALY,
+            status=200,
+        )
+        # Non-sprint weekend — sprint endpoint returns 404
+        responses.add(
+            responses.GET,
+            f"{F1_BASE}/current/last/sprint",
+            json={"error": "not found"},
+            status=404,
+        )
+
+        # Saturday of the Imola race weekend (race is Sunday May 17)
+        tool = F1Tool(today=date(2026, 5, 16))
+        result = tool.execute({"user_input": "F1"})
+
+        assert "QUALIFYING" in result
+        assert "Antonelli" in result
+        assert "1:27.798" in result
+        # Sprint should not appear since the endpoint 404'd
+        assert "SPRINT" not in result
+
+    @responses.activate
+    def test_includes_sprint_on_sprint_weekend(self):
+        _register_core_endpoints()
+        responses.add(
+            responses.GET,
+            f"{F1_BASE}/current/next",
+            json=NEXT_RACE_SPRINT_WEEKEND,
+            status=200,
+        )
+        responses.add(
+            responses.GET,
+            f"{F1_BASE}/current/last/qualy",
+            json=LAST_QUALY,
+            status=200,
+        )
+        responses.add(
+            responses.GET,
+            f"{F1_BASE}/current/last/sprint",
+            json=LAST_SPRINT,
+            status=200,
+        )
+
+        # Saturday of Spa sprint weekend (race is Sunday May 24)
+        tool = F1Tool(today=date(2026, 5, 23))
+        result = tool.execute({"user_input": "F1"})
+
+        assert "SPRINT" in result
+        assert "Verstappen" in result
+        # Sprint date is provided in next race schedule, indicating sprint weekend
+        assert "QUALIFYING" in result
+
+    @responses.activate
+    def test_friday_is_in_race_weekend(self):
+        _register_core_endpoints()
+        responses.add(
+            responses.GET,
+            f"{F1_BASE}/current/next",
+            json=NEXT_RACE,
+            status=200,
+        )
+        responses.add(
+            responses.GET,
+            f"{F1_BASE}/current/last/qualy",
+            json=LAST_QUALY,
+            status=200,
+        )
+        responses.add(
+            responses.GET,
+            f"{F1_BASE}/current/last/sprint",
+            json={"error": "not found"},
+            status=404,
+        )
+
+        # Friday of Imola race weekend
+        tool = F1Tool(today=date(2026, 5, 15))
+        result = tool.execute({"user_input": "F1"})
+        assert "QUALIFYING" in result
+
+    @responses.activate
+    def test_sunday_is_in_race_weekend(self):
+        _register_core_endpoints()
+        responses.add(
+            responses.GET,
+            f"{F1_BASE}/current/next",
+            json=NEXT_RACE,
+            status=200,
+        )
+        responses.add(
+            responses.GET,
+            f"{F1_BASE}/current/last/qualy",
+            json=LAST_QUALY,
+            status=200,
+        )
+        responses.add(
+            responses.GET,
+            f"{F1_BASE}/current/last/sprint",
+            json={"error": "not found"},
+            status=404,
+        )
+
+        tool = F1Tool(today=date(2026, 5, 17))
+        result = tool.execute({"user_input": "F1"})
+        assert "QUALIFYING" in result
+
+
+class TestF1ToolErrorHandling:
+    """Failure modes of the F1 tool."""
+
+    @responses.activate
+    def test_standings_failure_returns_error_string(self):
+        responses.add(
+            responses.GET,
+            f"{F1_BASE}/current/drivers-championship",
+            json={"error": "server error"},
+            status=500,
+        )
+        # Other endpoints succeed
+        responses.add(
+            responses.GET,
+            f"{F1_BASE}/current/constructors-championship",
+            json=CONSTRUCTOR_STANDINGS,
+            status=200,
+        )
+        responses.add(
+            responses.GET,
+            f"{F1_BASE}/current/last/race",
+            json=LAST_RACE,
+            status=200,
+        )
+        responses.add(
+            responses.GET,
+            f"{F1_BASE}/current/next",
+            json=NEXT_RACE,
+            status=200,
+        )
+
+        tool = F1Tool(today=date(2026, 5, 12))
+        result = tool.execute({"user_input": "F1"})
+
+        # Driver standings section should mark error but others still appear
+        assert "DRIVER STANDINGS" in result
+        assert "unavailable" in result.lower() or "error" in result.lower()
+        assert "Miami Grand Prix" in result  # last race still rendered
+        assert "Emilia-Romagna Grand Prix" in result  # next race still rendered
+
+
+class TestF1ToolFactory:
+    """Factory integration."""
+
+    def test_create_f1_tool_default(self):
+        tool = create_tool({"type": "f1"})
+        assert isinstance(tool, F1Tool)
+        assert tool.base_url == F1_BASE
+
+    def test_create_f1_tool_with_overrides(self):
+        tool = create_tool(
+            {
+                "type": "f1",
+                "base_url": "https://example.com/api",
+                "request_timeout": 25,
+            }
+        )
+        assert tool.base_url == "https://example.com/api"
+        assert tool.request_timeout == 25


### PR DESCRIPTION
## Summary

- Adds an `f1` tool backed by the public [f1api.dev](https://f1api.dev) API (no auth required).
- Adds a `/F1` slash command that produces an F1 briefing: current drivers' & constructors' standings, last race podium, and next race details.
- During a race weekend (Fri–Sun of the next race), the tool also surfaces the most recent qualifying results, and on sprint weekends it includes sprint results too. Non-sprint weekends and other partial API failures degrade gracefully.

## Files

- `src/tools/implementations/f1.py` — new `F1Tool` (Tool ABC), formats payloads for the LLM and handles 404/error fallbacks.
- `src/tools/factory.py` — registers `type: "f1"` (both fields optional: `base_url`, `request_timeout`).
- `config/config.example.yaml` — `/F1` slash command using `anthropic/claude-3.5-sonnet`.
- `tests/unit/test_f1_tool.py` — 11 tests covering weekend window edges (Fri/Sat/Sun), sprint weekends, non-sprint 404 handling, error fallback, factory wiring.
- `README.md` — docs for the new tool and command.

## Local checks

- `black --check src/ tests/` — clean
- `pylint src/ --exit-zero` — 8.82/10 (improved from 8.35/10)
- `pytest tests/unit --cov=src` — 98 passed
- `pytest tests/integration` — 3 passed

## Test plan

- [ ] CI passes (tests + format check)
- [ ] Add the `/F1` slash command in the Slack app config
- [ ] Copy the `/F1` block from `config.example.yaml` into the real `config.yaml`
- [ ] Verify `/F1` returns standings + last podium + next race outside a race weekend
- [ ] Verify qualy section appears Fri–Sun of an upcoming race
- [ ] Verify sprint section appears on a sprint weekend

🤖 Generated with [Claude Code](https://claude.com/claude-code)