### PR TITLE
fix: handle next-race 'race' field as list in F1 tool

### DIFF
--- a/src/tools/implementations/f1.py
+++ b/src/tools/implementations/f1.py
@@ -90,8 +90,19 @@ class F1Tool(Tool):
         weekend_start = race_date - timedelta(days=2)
         return weekend_start <= today <= race_date
 
+    def _next_race_object(
+        self, next_race_payload: Optional[Dict[str, Any]]
+    ) -> Dict[str, Any]:
+        """Return the next-race object, tolerating both dict and single-element list shapes."""
+        race = (next_race_payload or {}).get("race")
+        if isinstance(race, list):
+            return race[0] if race else {}
+        if isinstance(race, dict):
+            return race
+        return {}
+
     def _is_sprint_weekend(self, next_race_payload: Optional[Dict[str, Any]]) -> bool:
-        race = (next_race_payload or {}).get("race") or {}
+        race = self._next_race_object(next_race_payload)
         schedule = race.get("schedule") or {}
         sprint_race = schedule.get("sprintRace") or {}
         return bool(sprint_race.get("date"))
@@ -99,7 +110,7 @@ class F1Tool(Tool):
     def _extract_next_race_date(
         self, next_race_payload: Optional[Dict[str, Any]]
     ) -> Optional[date]:
-        race = (next_race_payload or {}).get("race") or {}
+        race = self._next_race_object(next_race_payload)
         schedule = race.get("schedule") or {}
         race_block = schedule.get("race") or {}
         date_str = race_block.get("date")
@@ -181,7 +192,7 @@ class F1Tool(Tool):
         header = "NEXT RACE:"
         if not payload:
             return f"{header}\n- unavailable"
-        race = payload.get("race") or {}
+        race = self._next_race_object(payload)
         if not race:
             return f"{header}\n- unavailable"
 

--- a/tests/unit/test_f1_tool.py
+++ b/tests/unit/test_f1_tool.py
@@ -423,6 +423,111 @@ class TestF1ToolRaceWeekend:
         assert "QUALIFYING" in result
 
 
+class TestF1ToolLiveApiShapes:
+    """Regression tests for actual f1api.dev response shapes."""
+
+    @responses.activate
+    def test_next_race_payload_with_race_as_single_element_list(self):
+        """The live API returns `race` as a one-element list, not a dict.
+
+        Previously crashed with: AttributeError: 'list' object has no attribute 'get'
+        """
+        _register_core_endpoints()
+
+        # Real-world shape: `race` is a list containing one object.
+        next_race_as_list = {
+            "season": 2026,
+            "round": 7,
+            "race": [
+                {
+                    "raceId": "canadian_2026",
+                    "raceName": "Formula 1 Lenovo Grand Prix Du Canada 2026",
+                    "round": 7,
+                    "schedule": {
+                        "race": {"date": "2026-05-24", "time": "18:00:00Z"},
+                        "qualy": {"date": "2026-05-23", "time": "20:00:00Z"},
+                        "fp1": {"date": "2026-05-22", "time": "17:30:00Z"},
+                        "fp2": {"date": None, "time": None},
+                        "fp3": {"date": None, "time": None},
+                        "sprintQualy": {"date": "2026-05-22", "time": "21:00:00Z"},
+                        "sprintRace": {"date": "2026-05-23", "time": "16:30:00Z"},
+                    },
+                    "circuit": {
+                        "circuitName": "Circuit Gilles Villeneuve",
+                        "country": "Canada",
+                        "city": "Montreal",
+                    },
+                }
+            ],
+        }
+        responses.add(
+            responses.GET,
+            f"{F1_BASE}/current/next",
+            json=next_race_as_list,
+            status=200,
+        )
+
+        # Tuesday before the weekend — should NOT trip race-weekend logic
+        tool = F1Tool(today=date(2026, 5, 19))
+        result = tool.execute({"user_input": "F1"})
+
+        assert "NEXT RACE" in result
+        assert "Canadian" in result or "Canada" in result
+        assert "Round 7" in result
+        assert "Montreal" in result
+        assert "2026-05-24" in result
+        # Sprint date is set in schedule, but we're outside the weekend window
+        # so the qualy/sprint endpoints shouldn't be called.
+        assert "QUALIFYING" not in result
+        assert "SPRINT RESULTS" not in result
+
+    @responses.activate
+    def test_race_as_list_during_sprint_weekend(self):
+        """`race` as a list AND we are inside the Fri-Sun window of a sprint weekend."""
+        _register_core_endpoints()
+        next_race_as_list = {
+            "season": 2026,
+            "round": 7,
+            "race": [
+                {
+                    "raceName": "Canadian Grand Prix",
+                    "round": 7,
+                    "schedule": {
+                        "race": {"date": "2026-05-24", "time": "18:00:00Z"},
+                        "qualy": {"date": "2026-05-23", "time": "20:00:00Z"},
+                        "sprintQualy": {"date": "2026-05-22", "time": "21:00:00Z"},
+                        "sprintRace": {"date": "2026-05-23", "time": "16:30:00Z"},
+                    },
+                    "circuit": {"circuitName": "Circuit Gilles Villeneuve"},
+                }
+            ],
+        }
+        responses.add(
+            responses.GET,
+            f"{F1_BASE}/current/next",
+            json=next_race_as_list,
+            status=200,
+        )
+        responses.add(
+            responses.GET,
+            f"{F1_BASE}/current/last/qualy",
+            json=LAST_QUALY,
+            status=200,
+        )
+        responses.add(
+            responses.GET,
+            f"{F1_BASE}/current/last/sprint",
+            json=LAST_SPRINT,
+            status=200,
+        )
+
+        # Saturday of the Canadian sprint weekend
+        tool = F1Tool(today=date(2026, 5, 23))
+        result = tool.execute({"user_input": "F1"})
+        assert "QUALIFYING" in result
+        assert "SPRINT" in result
+
+
 class TestF1ToolErrorHandling:
     """Failure modes of the F1 tool."""
 


### PR DESCRIPTION
## Summary

The live `f1api.dev` `/current/next` endpoint returns the `race` key as a
**single-element list**, not the dict the initial implementation assumed.
That mismatch raised `AttributeError: 'list' object has no attribute 'get'`
inside `_format_next_race`, the entire `F1Tool.execute()` aborted, the
tool returned no enrichment, and the LLM fell back to training-data
knowledge — producing a confidently wrong 2024-season briefing in
production.

### Observed error
```
File "/app/src/tools/implementations/f1.py", line 188, in _format_next_race
    name = race.get("raceName") or "Unknown"
AttributeError: 'list' object has no attribute 'get'
```

### Fix

- Added a shape-tolerant `_next_race_object()` accessor used by
  `_format_next_race`, `_is_sprint_weekend`, and `_extract_next_race_date`.
  Accepts either `race: {...}` or `race: [{...}]`.
- Two new regression tests in `tests/unit/test_f1_tool.py` modeled on the
  actual live response shape, covering both the outside-weekend and
  inside-sprint-weekend paths.

### Local checks

- `black --check` — clean
- `pytest tests/unit tests/integration` — 103 passed (13 F1 tests)

### Why this got through the first PR

The initial fixtures were built from `WebFetch` summarizations of the
API docs rather than the raw JSON of the live endpoint. The doc page
described `race` as an object, but in practice the endpoint returns a
one-element list. The new regression tests pin the real shape so this
class of mismatch surfaces in CI.

## Test plan

- [ ] CI passes
- [ ] Run `/F1` in Slack outside a race weekend — verify standings + last podium + next race render correctly
- [ ] Verify response references the 2026 season (not stale training data)

🤖 Generated with [Claude Code](https://claude.com/claude-code)