### PR TITLE
chore(renovate): auto-merge lockFileMaintenance PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -101,6 +101,7 @@
   },
   "lockFileMaintenance": {
     "enabled": true,
+    "automerge": true,
     "schedule": [
       "before 4am on monday"
     ]


### PR DESCRIPTION
## Summary
- After the uv migration (#77), Renovate's `pep621` manager owns `uv.lock` and `lockFileMaintenance` will produce weekly refresh PRs.
- `lockFileMaintenance` does not inherit the top-level `automerge: true` — it defaults to `automerge: false`. This flips it on so `uv.lock` refresh PRs auto-merge like the rest of the non-major updates.
- Audited the rest of `renovate.json` against the new uv setup: no stale `pip_requirements` rules, Docker digest pinning still covers `python:3.14-slim` and `ghcr.io/astral-sh/uv` in the Dockerfile, the `all-minor-patch` group is manager-agnostic, and the GitHub Actions manager remains enabled via `config:recommended`. No other edits required.

## Test plan
- [ ] Renovate dashboard issue reflects the updated config on its next run
- [ ] Next weekly `lockFileMaintenance` PR (Monday before 4am ET) opens and auto-merges once CI passes
- [ ] Confirm no regressions in existing non-major / digest auto-merge behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)