### PR TITLE
ci: point osv-scanner at uv.lock directly

### DIFF
--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -44,8 +44,7 @@ jobs:
         uses: google/osv-scanner-action/osv-scanner-action@v2.3.8
         with:
           scan-args: |-
-            --recursive
-            ./
+            --lockfile=uv.lock
 
       - name: pip-audit
         uses: pypa/gh-action-pip-audit@v1.1.0


### PR DESCRIPTION
## Summary
- Replace `--recursive ./` with `--lockfile=uv.lock` for the OSV scan step.
- Avoids redundant scan of the exported `requirements-lock.txt`, which was triggering a deps.dev gRPC call to resolve transitive deps and failing the action when that service was unavailable (exit 127 with zero findings).
- `uv.lock` is already fully resolved, so coverage is unchanged; `pip-audit` still independently scans `requirements-lock.txt` as a second opinion.

## Test plan
- [ ] CI green on this PR (no deps.dev RPC call in OSV step)
- [ ] OSV step still reports on uv.lock contents
- [ ] pip-audit step still runs against requirements-lock.txt

🤖 Generated with [Claude Code](https://claude.com/claude-code)