### PR TITLE
ci: switch GHCR retention to multi-arch-aware cleanup action

### DIFF
--- a/.github/workflows/ghcr-retention.yml
+++ b/.github/workflows/ghcr-retention.yml
@@ -13,26 +13,12 @@ jobs:
   prune:
     name: Prune old GHCR versions
     runs-on: ubuntu-latest
+    concurrency:
+      group: ghcr-cleanup-${{ github.repository }}
     steps:
-      # Step 1: Prune from the full version pool, but preserve `latest`.
-      # Always keeps the 5 most recent versions regardless of tag, so the
-      # last 5 sha-* tagged builds survive for rollback.
-      - name: Prune tagged + untagged (keep latest + last 5)
-        uses: actions/delete-package-versions@v5
-        continue-on-error: true
+      - name: Prune GHCR (keep latest + 5 most recent tagged)
+        uses: dataaxiom/ghcr-cleanup-action@v1.2.0
         with:
-          package-name: ${{ github.event.repository.name }}
-          package-type: container
-          min-versions-to-keep: 5
-          ignore-versions: '^latest$'
-
-      # Step 2: Explicit cleanup of untagged versions (build cache layers,
-      # orphaned manifests). Keeps the 5 most recent untagged for safety.
-      - name: Prune untagged only (keep last 5 untagged)
-        uses: actions/delete-package-versions@v5
-        continue-on-error: true
-        with:
-          package-name: ${{ github.event.repository.name }}
-          package-type: container
-          min-versions-to-keep: 5
-          delete-only-untagged-versions: 'true'
+          keep-n-tagged: 5
+          exclude-tags: latest
+          delete-untagged: true


### PR DESCRIPTION
## Summary
- Replaces `actions/delete-package-versions@v5` (which matches `ignore-versions` against container digests, not tags) with [`dataaxiom/ghcr-cleanup-action@v1.2.0`](https://github.com/dataaxiom/ghcr-cleanup-action), which is multi-arch aware and tag-aware.
- Fixes the prior workflow's behavior where a manual run deleted the full package: `^latest$` matched nothing, and the action couldn't tell apart manifest lists from their referenced untagged platform layers.
- New policy is unchanged in intent: keep `latest` always, keep the 5 most recent tagged manifests, delete orphan untagged versions.
- Pinned to `v1.2.0`, the current latest tagged release (published 2 days ago, no v2 exists).

## Test plan
- [ ] Manual `workflow_dispatch` from the PR branch (or after merge) and confirm:
  - `latest` tag still resolves
  - 5 most recent `sha-*` tags still present
  - Orphan untagged platform layers (not referenced by a kept manifest) removed
- [ ] No deletion of platform children of kept multi-arch manifests

🤖 Generated with [Claude Code](https://claude.com/claude-code)