### PR TITLE
chore(renovate): group Chainguard python builder+runtime into one PR

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -91,6 +91,14 @@
         "traefik"
       ],
       "minimumReleaseAge": "1 day"
+    },
+    {
+      "description": "Keep the Chainguard builder (python:latest-dev) and runtime (python:latest) in lockstep — one PR, never desynced, so the venv copied from the builder always matches the runtime Python.",
+      "matchDepNames": [
+        "cgr.dev/chainguard/python"
+      ],
+      "groupName": "chainguard python base images",
+      "groupSlug": "chainguard-python-base"
     }
   ],
   "vulnerabilityAlerts": {


### PR DESCRIPTION
## Summary
Adds a Renovate package rule grouping `cgr.dev/chainguard/python` (`:latest-dev` builder and `:latest` runtime) into a single "chainguard python base images" PR. The Dockerfile copies a venv built in the builder into the runtime; if the two digests roll separately, a Python minor bump landing in only one of them breaks the `site-packages/python3.x` path. This keeps Mend updating both FROM lines together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)